### PR TITLE
fix: required params to get Google API working

### DIFF
--- a/youtube/Add_ons.py
+++ b/youtube/Add_ons.py
@@ -73,6 +73,9 @@ def Get_vid_info_url(vid:str,whaturl:str) -> str:
 		"ps":"default",
 		"eurl":whaturl,
 		"hl":"en_US",
+		"html5": "1",
+                "c": "TVHTML5",
+                "cver": "6.20180913"
 	}
 	return "https://youtube.com/get_video_info?"+"&".join(f"{n}={m}" for n,m in params.items())
 	
@@ -92,6 +95,9 @@ def Get_r_vid_info_url(vid:str) -> str:
 		"video_id":vid,
 		"eurl":f"https://youtube.googleapis.com/v/{vid}",
 		"sts":"",
+		"html5": "1",
+                "c": "TVHTML5",
+                "cver": "6.20180913"
 	}
 	return "https://youtube.com/get_video_info?"+"&".join(f"{n}={m}" for n,m in params.items())
 


### PR DESCRIPTION
Google has changed endpoints args, and it is new args were added to make it work again.

See more: https://stackoverflow.com/questions/67615278/get-video-info-youtube-endpoint-suddenly-returning-404-not-found